### PR TITLE
add option for disabling staticMap or multiStaticMap

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -127,6 +127,14 @@
         "providerURL": "Your Nominatim Server Address",
         "staticProvider": "none",
         "staticProviderURL": "Your TileServerCache Server Address",
+        "staticMapType": {
+          "pokemon": "staticMap",
+          "raid": "staticMap",
+          "pokestop": "staticMap",
+          "quest": "staticMap",
+          "weather": "staticMap",
+          "location": "staticMap"
+        },
         "geocodingKey":["Your Google Geocoding Key if you Use google as provider"],
         "staticKey":["Your MapQuest or Google Key"],
         "width": 320,

--- a/src/controllers/monster.js
+++ b/src/controllers/monster.js
@@ -335,8 +335,8 @@ class Monster extends Controller {
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 			const jobs = []
 
-			if (pregenerateTile) {
-				data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'monster', data)
+			if (pregenerateTile && this.config.geocoding.staticMapType.pokemon) {
+				data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'monster', data, this.config.geocoding.staticMapType.pokemon)
 				this.log.debug(`${logReference}: Tile generated ${data.staticMap}`)
 			}
 			data.staticmap = data.staticMap // deprecated

--- a/src/controllers/pokestop.js
+++ b/src/controllers/pokestop.js
@@ -170,8 +170,8 @@ class Pokestop extends Controller {
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 			const jobs = []
 
-			if (pregenerateTile) {
-				data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'pokestop', data)
+			if (pregenerateTile && this.config.geocoding.staticMapType.pokestop) {
+				data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'pokestop', data, this.config.geocoding.staticMapType.pokestop)
 				this.log.debug(`${logReference}: Tile generated ${data.staticMap}`)
 			}
 			data.staticmap = data.staticMap // deprecated

--- a/src/controllers/quest.js
+++ b/src/controllers/quest.js
@@ -183,8 +183,8 @@ class Quest extends Controller {
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 			const jobs = []
 
-			if (pregenerateTile) {
-				data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'quest', data)
+			if (pregenerateTile && this.config.geocoding.staticMapType.quest) {
+				data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'quest', data, this.config.geocoding.staticMapType.quest)
 				this.log.debug(`${logReference}: Tile generated ${data.staticMap}`)
 			}
 

--- a/src/controllers/raid.js
+++ b/src/controllers/raid.js
@@ -246,8 +246,8 @@ class Raid extends Controller {
 				const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 				const jobs = []
 
-				if (pregenerateTile) {
-					data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'raid', data)
+				if (pregenerateTile && this.config.geocoding.staticMapType.raid) {
+					data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'raid', data, this.config.geocoding.staticMapType.raid)
 					this.log.debug(`${logReference}: Tile generated ${data.staticMap}`)
 				}
 				data.staticmap = data.staticMap // deprecated
@@ -387,8 +387,8 @@ class Raid extends Controller {
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 			const jobs = []
 
-			if (pregenerateTile) {
-				data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'raid', data)
+			if (pregenerateTile && this.config.geocoding.staticMapType.raid) {
+				data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'raid', data, this.config.geocoding.staticMapType.raid)
 				this.log.debug(`${logReference}: Tile generated ${data.staticMap}`)
 			}
 			data.staticmap = data.staticMap // deprecated

--- a/src/controllers/weather.js
+++ b/src/controllers/weather.js
@@ -330,8 +330,8 @@ class Weather extends Controller {
 
 			const geoResult = await this.getAddress({ lat: data.latitude, lon: data.longitude })
 
-			if (pregenerateTile && !this.config.weather.showAlteredPokemonStaticMap) {
-				data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'weather', data)
+			if (pregenerateTile && this.config.geocoding.staticMapType.weather && !this.config.weather.showAlteredPokemonStaticMap) {
+				data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'weather', data, this.config.geocoding.staticMapType.weather)
 				this.log.debug(`${logReference}: Tile generated ${data.staticMap}`)
 			}
 
@@ -382,8 +382,8 @@ class Weather extends Controller {
 
 					data.activePokemons = activePokemons.slice(0, this.config.weather.showAlteredPokemonMaxCount) || null
 				}
-				if (pregenerateTile && this.config.weather.showAlteredPokemon && this.config.weather.showAlteredPokemonStaticMap) {
-					data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'weather', data)
+				if (pregenerateTile && this.config.geocoding.staticMapType.weather && this.config.weather.showAlteredPokemon && this.config.weather.showAlteredPokemonStaticMap) {
+					data.staticMap = await this.tileserverPregen.getPregeneratedTileURL(logReference, 'weather', data, this.config.geocoding.staticMapType.weather)
 					this.log.debug(`${logReference}: Tile generated ${data.staticMap}`)
 				}
 				data.staticmap = data.staticMap // deprecated

--- a/src/lib/poracleMessage/commands/location.js
+++ b/src/lib/poracleMessage/commands/location.js
@@ -52,7 +52,7 @@ exports.run = async (client, msg, args) => {
 		message = `👋, ${translator.translate('I set ')}${target.name}${translator.translate('\'s location to the following coordinates in')}${placeConfirmation}:\n${maplink}`
 
 		if (platform === 'discord' && client.config.geocoding.staticProvider.toLowerCase() === 'tileservercache') {
-			staticMap = await client.query.tileserverPregen.getPregeneratedTileURL('location', 'location', { latitude: lat, longitude: lon }, this.config.geocoding.staticMapType.location)
+			staticMap = await client.query.tileserverPregen.getPregeneratedTileURL('location', 'location', { latitude: lat, longitude: lon }, client.config.geocoding.staticMapType.location)
 			message = {
 				embed: {
 					color: 0x00ff00,

--- a/src/lib/poracleMessage/commands/location.js
+++ b/src/lib/poracleMessage/commands/location.js
@@ -52,7 +52,7 @@ exports.run = async (client, msg, args) => {
 		message = `👋, ${translator.translate('I set ')}${target.name}${translator.translate('\'s location to the following coordinates in')}${placeConfirmation}:\n${maplink}`
 
 		if (platform === 'discord' && client.config.geocoding.staticProvider.toLowerCase() === 'tileservercache') {
-			staticMap = await client.query.tileserverPregen.getPregeneratedTileURL('location', 'location', { latitude: lat, longitude: lon })
+			staticMap = await client.query.tileserverPregen.getPregeneratedTileURL('location', 'location', { latitude: lat, longitude: lon }, this.config.geocoding.staticMapType.location)
 			message = {
 				embed: {
 					color: 0x00ff00,

--- a/src/lib/poracleMessage/commands/location.js
+++ b/src/lib/poracleMessage/commands/location.js
@@ -51,7 +51,7 @@ exports.run = async (client, msg, args) => {
 		const maplink = `https://www.google.com/maps/search/?api=1&query=${lat},${lon}`
 		message = `👋, ${translator.translate('I set ')}${target.name}${translator.translate('\'s location to the following coordinates in')}${placeConfirmation}:\n${maplink}`
 
-		if (platform === 'discord' && client.config.geocoding.staticProvider.toLowerCase() === 'tileservercache') {
+		if (platform === 'discord' && client.config.geocoding.staticMapType.location && client.config.geocoding.staticProvider.toLowerCase() === 'tileservercache') {
 			staticMap = await client.query.tileserverPregen.getPregeneratedTileURL('location', 'location', { latitude: lat, longitude: lon }, client.config.geocoding.staticMapType.location)
 			message = {
 				embed: {

--- a/src/lib/tileserverPregen.js
+++ b/src/lib/tileserverPregen.js
@@ -7,24 +7,30 @@ class TileserverPregen {
 		this.config = config
 	}
 
-	async getPregeneratedTileURL(logReference, type, data) {
-		const url = `${this.config.geocoding.staticProviderURL}/staticmap/poracle-${type}?pregenerate=true&regeneratable=true`
+	async getPregeneratedTileURL(logReference, type, data, staticMapType) {
+		let mapType = 'staticmap'
+		let templateType = ''
+		if (staticMapType === 'multiStaticMap') {
+			mapType = 'multistaticmap'
+			templateType = 'multi-'
+		}
+		const url = `${this.config.geocoding.staticProviderURL}/${mapType}/poracle-${templateType}${type}?pregenerate=true&regeneratable=true`
 		try {
 			this.log.debug(`${logReference}: Pre-generating static map ${url}`)
 			const result = await axios.post(url, data)
 			if (result.status !== 200) {
-				this.log.warn(`${logReference}: Failed to Pregenerate StaticMap. Got ${result.status}. Error: ${result.data ? result.data.reason : '?'}.`)
+				this.log.warn(`${logReference}: Failed to Pregenerate ${templateType}StaticMap. Got ${result.status}. Error: ${result.data ? result.data.reason : '?'}.`)
 				return null
 			} if (typeof result.data !== 'string') {
-				this.log.warn(`${logReference}: Failed to Pregenerate StaticMap. No id returned.`)
+				this.log.warn(`${logReference}: Failed to Pregenerate ${templateType}StaticMap. No id returned.`)
 				return null
 			}
-			return `${this.config.geocoding.staticProviderURL}/staticmap/pregenerated/${result.data}`
+			return `${this.config.geocoding.staticProviderURL}/${mapType}/pregenerated/${result.data}`
 		} catch (error) {
 			if (error.response) {
-				this.log.warn(`${logReference}: Failed to Pregenerate StaticMap. Got ${error.response.status}. Error: ${error.response.data ? error.response.data.reason : '?'}.`)
+				this.log.warn(`${logReference}: Failed to Pregenerate ${templateType}StaticMap. Got ${error.response.status}. Error: ${error.response.data ? error.response.data.reason : '?'}.`)
 			} else {
-				this.log.warn(`${logReference}: Failed to Pregenerate StaticMap. Error: ${error}.`)
+				this.log.warn(`${logReference}: Failed to Pregenerate ${templateType}StaticMap. Error: ${error}.`)
 			}
 			return null
 		}


### PR DESCRIPTION
Adding options for static map:
new section in `config > geocoding`:
```
        "staticMapType": {
          "pokemon": "staticMap",
          "raid": "staticMap",
          "pokestop": "staticMap",
          "quest": false,
          "weather": "staticMap",
          "location": "staticMap"
        },
```
Options are:
- `false` : disabled for this type of event
- `"staticMap"` : normal static map (expecting template named like `poracle-monster.json`)
- `"multiStaticMap"` : multi static map (expecting template named like `poracle-multi-monster.json`)
